### PR TITLE
feat: make dropping cases optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ If you are matching on multiple populations within the same project, you may wan
 `output_path` (default: `"output"`)\
 The folder where the outputs (CSVs and matching report) should be saved.
 
+`drop_cases_from_matches` (default: `False`)\
+If `True`, all `patient_id`s in the case CSV are dropped from the match CSV before matching starts.
+
 ## Outputs
 
 ### Datasets

--- a/osmatching/osmatching.py
+++ b/osmatching/osmatching.py
@@ -134,7 +134,7 @@ def date_exclusions(df1, date_exclusion_variables, index_date):
     exclusions = pd.Series(data=False, index=df1.index)
     for exclusion_var, before_after in date_exclusion_variables.items():
         if before_after == "before":
-            variable_bool = df1[exclusion_var] <= index_date
+            variable_bool = df1[exclusion_var] < index_date
         elif before_after == "after":
             variable_bool = df1[exclusion_var] > index_date
         else:

--- a/osmatching/osmatching.py
+++ b/osmatching/osmatching.py
@@ -203,6 +203,7 @@ def match(
     indicator_variable_name="case",
     output_suffix="",
     output_path="output",
+    drop_cases_from_matches=False
 ):
     """
     Wrapper function that calls functions to:
@@ -262,10 +263,9 @@ def match(
         ],
     )
 
-    ## Drop cases from match population
-    ## WARNING - this will cause issues in dummy data where population
-    ## sizes are the same, as the indices will be identical.
-    matches = matches.drop(cases.index, errors="ignore")
+    ## Drop cases from match population if specified
+    if drop_cases_from_matches:
+        matches = matches.drop(cases.index, errors="ignore")
 
     matching_report(
         [

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -193,7 +193,7 @@ def test_date_exclusions():
     excl = date_exclusions(df1, date_exclusion_variables, index_date)
     excl_ser = date_exclusions(df1, date_exclusion_variables, index_date_series)
 
-    assert excl.equals(pd.Series([True, True, False, True, False, True]))
+    assert excl.equals(pd.Series([True, False, False, True, False, True]))
     assert excl_ser.equals(pd.Series([True, False, False, True, False, True]))
 
 


### PR DESCRIPTION
Often we would not want to exclude cases from matches, rather, they should be censored at the time that they become cases. I've therefore made the default to not exclude them.